### PR TITLE
deprecate old push/patch commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine
+FROM node:8.17.0-alpine3.10
 
-MAINTAINER Ajish Balakrishnan <ajish@hackerrank.com>
+MAINTAINER Anurag Tiwari <anurag@hackerrank.com>
 
 # Install dependencies
 # For line 14: https://github.com/nodejs/docker-node/issues/813#issuecomment-407339011
@@ -11,7 +11,7 @@ RUN apk update && apk upgrade \
   && apk add git \
   && apk add openssh\
   && apk add redis \
-  && apk add --update nodejs nodejs-npm \
+  # && apk add --update nodejs nodejs-npm \
   && npm config set unsafe-perm true \
   && apk add python \
   && apk add curl \
@@ -29,7 +29,7 @@ USER  hubot
 WORKDIR /hubot
 
 # Install hubot
-RUN yo hubot --owner="Ajish Balakrishnan <ajish@hackerrank.com>" --name="prebot" --description="Hackzoid's friend in pre-prod world" --defaults
+RUN yo hubot --owner="Anurag Tiwari <anurag@hackerrank.com>" --name="prebot" --description="Hackzoid's friend in pre-prod world" --defaults
 COPY package.json package.json
 
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apk update && apk upgrade \
   && apk add git \
   && apk add openssh\
   && apk add redis \
-  # && apk add --update nodejs nodejs-npm \
   && npm config set unsafe-perm true \
   && apk add python \
   && apk add curl \

--- a/scripts/prebot.coffee
+++ b/scripts/prebot.coffee
@@ -83,6 +83,7 @@ module.exports = (robot) ->
         nodeDebug:           buildconfig['nodeDebug']  || 'false',
         hrc:                 buildconfig['hrc']        || 'false',
         hrw:                 buildconfig['hrw']        || 'false',
+        rba:                 buildconfig['rba']        || 'false',
         metrics:             buildconfig['metrics']    || 'false'
       }
 

--- a/scripts/prebot.coffee
+++ b/scripts/prebot.coffee
@@ -64,7 +64,7 @@ module.exports = (robot) ->
 
   new cronJob('00 */5 * * * *', purgeExpiredNamespaces, null, true)
 
-  robot.respond /(deploy|newpush|patch) (.+)/i, (msg) ->
+  robot.respond /(deploy|patch) (.+)/i, (msg) ->
     action = msg.match[1]
     buildconfigArray = msg.match[2].match(/\S+/g)
     buildconfig = {}

--- a/scripts/prebot.coffee
+++ b/scripts/prebot.coffee
@@ -64,12 +64,12 @@ module.exports = (robot) ->
 
   new cronJob('00 */5 * * * *', purgeExpiredNamespaces, null, true)
 
-  robot.respond /(deploy|newpush) (.+)/i, (msg) ->
+  robot.respond /(deploy|newpush|patch) (.+)/i, (msg) ->
     action = msg.match[1]
     buildconfigArray = msg.match[2].match(/\S+/g)
     buildconfig = {}
     buildconfigArray.map (val) ->
-      [k,v] = val.split("=")
+      [k, v] = val.split("=")
       buildconfig[k] = v
     expiryTime = (new Date()).getTime() + ((buildconfig['ttl'] || 48) * 60 * 60 * 1000)
     jobsToBuild = []
@@ -93,87 +93,11 @@ module.exports = (robot) ->
           sudorank:          'true',
           crons:             'true'
         })
-      jenkinsBuild(msg, 'private-hackerrank-build', options)
-      client.zadd("live-namespaces", expiryTime, "hackerrank::#{buildconfig['node']}")
 
-      if buildconfig['sourcing']
-        options = {
-          nodename: buildconfig['node'],
-          branch_name:  buildconfig['sourcing'] || 'master',
-          ops_branch: buildconfig['ops'] || 'master'
-        }
-        jenkinsBuild(msg, 'k8s-private-sourcing', options)
-        client.zadd("live-namespaces", expiryTime, "sourcing::#{buildconfig['node']}")
-
-      if buildconfig['content']
-        options = {
-          nodename: buildconfig['node'],
-          content_branch:  buildconfig['content'] || 'master',
-          namespace: buildconfig['namespace'] || buildconfig['node']
-          ops_branch: buildconfig['ops'] || 'master'
-        }
-        client.zadd("live-namespaces", expiryTime, "content::#{buildconfig['node']}")
-        jenkinsBuild(msg, 'k8s-private-content', options)
-
-      if buildconfig['candidate']
-        options = {
-          nodename: buildconfig['node'],
-          branch:  buildconfig['candidate'],
-          namespace: buildconfig['namespace'] || buildconfig['node'],
-          ops_branch: buildconfig['ops'] || 'master'
-        }
-        client.zadd("live-namespaces", expiryTime, "candidate::#{buildconfig['node']}")
-        jenkinsBuild(msg, 'k8s-preprod-candidate-site', options)
-
-      services = ['auth', 'keycloak']
-      services.forEach (service) ->
-        if buildconfig[service]
-          options = {
-            nodename: buildconfig['node'],
-            branch_name:  buildconfig[service] || 'master',
-            ops_branch: buildconfig['ops'] || 'master'
-          }
-          client.zadd("live-namespaces", expiryTime, "#{service}::#{buildconfig['node']}")
-          jenkinsBuild(msg, "k8s-private-#{service}", options)
-
-  robot.respond /(push|patch) (.+)/i, (msg) ->
-    action = msg.match[1]
-    buildconfigArray = msg.match[2].match(/\S+/g)
-    buildconfig = {}
-    buildconfigArray.map (val) ->
-      [k, v] = val.split("=")
-      buildconfig[k] = v
-    expiryTime = (new Date()).getTime() + ((buildconfig['ttl'] || 48) * 60 * 60 * 1000)
-    jobsToBuild = []
-    if buildconfig['node']
-      options = {
-        nodename: buildconfig['node'],
-        hackerrank_branch:  buildconfig['backend'] || 'master',
-        frontendcore_branch: buildconfig['frontend'] || 'master'
-        ops_branch: buildconfig['ops'] || 'master'
-        rba: buildconfig['rba'] || 'false'
-        railsDebug: buildconfig['railsDebug'] || 'false'
-        nodeDebug: buildconfig['nodeDebug'] || 'false'
-      }
-      if buildconfig['node'] == 'workers'
-        options = Object.assign(options, {
-          workers: 'true',
-          rba: 'true'
-        })
       if action != 'patch'
-        jenkinsBuild(msg, 'k8s-private', options)
+        jenkinsBuild(msg, 'private-hackerrank-build', options)
         client.zadd("live-namespaces", expiryTime, "hackerrank::#{buildconfig['node']}")
 
-      if buildconfig['candidate']
-        options = {
-          nodename: buildconfig['node'],
-          branch:  buildconfig['candidate'],
-          namespace: buildconfig['namespace'] || buildconfig['node'],
-          ops_branch: buildconfig['ops'] || 'master'
-        }
-        client.zadd("live-namespaces", expiryTime, "candidate::#{buildconfig['node']}")
-        jenkinsBuild(msg, 'k8s-preprod-candidate-site', options)
-
       if buildconfig['content']
         options = {
           nodename: buildconfig['node'],
@@ -183,6 +107,16 @@ module.exports = (robot) ->
         }
         client.zadd("live-namespaces", expiryTime, "content::#{buildconfig['node']}")
         jenkinsBuild(msg, 'k8s-private-content', options)
+
+      if buildconfig['candidate']
+        options = {
+          nodename: buildconfig['node'],
+          branch:  buildconfig['candidate'],
+          namespace: buildconfig['namespace'] || buildconfig['node'],
+          ops_branch: buildconfig['ops'] || 'master'
+        }
+        client.zadd("live-namespaces", expiryTime, "candidate::#{buildconfig['node']}")
+        jenkinsBuild(msg, 'k8s-preprod-candidate-site', options)
 
       if buildconfig['qa']
         jenkinsBuild(msg, 'create-qa-test-branch', {'TRIGGERING_USER': msg.envelope.user.name})


### PR DESCRIPTION
Signed-off-by: Anurag Tiwari <tiwari.anurag126@gmail.com>


Changes made -

1. Deprecate old push/patch commands.
2. Fix the docker build issue because of the higher node version than supported.
3. Allow patch command in the new deploy pipeline.